### PR TITLE
onPrepareContext script support

### DIFF
--- a/james-agent-common/src/main/java/com/tomtom/james/common/api/informationpoint/InformationPoint.java
+++ b/james-agent-common/src/main/java/com/tomtom/james/common/api/informationpoint/InformationPoint.java
@@ -27,6 +27,7 @@ public class InformationPoint {
     protected String script;
     protected Integer sampleRate;
     protected Metadata metadata;
+    protected Boolean requiresInitialContext;
 
     public InformationPoint() {
         metadata = new Metadata();
@@ -54,6 +55,10 @@ public class InformationPoint {
         } else {
             return Collections.emptyList();
         }
+    }
+
+    public Boolean getRequiresInitialContext() {
+        return requiresInitialContext;
     }
 
     public Metadata getMetadata() {
@@ -93,6 +98,7 @@ public class InformationPoint {
         private String script;
         private Integer sampleRate;
         private Metadata metadata;
+        private Boolean requireInitialContext;
 
         private Builder() {
             metadata = new Metadata();
@@ -120,6 +126,9 @@ public class InformationPoint {
 
         public Builder withScript(String script) {
             this.script = script;
+            if (script.contains(" onPrepareContext")) {
+                this.requireInitialContext = true;
+            }
             return this;
         }
 
@@ -140,6 +149,7 @@ public class InformationPoint {
             this.script = copyFrom.script;
             this.sampleRate = copyFrom.sampleRate;
             this.metadata.putAll(copyFrom.metadata);
+            this.requireInitialContext = copyFrom.requiresInitialContext;
             return this;
         }
 
@@ -150,6 +160,7 @@ public class InformationPoint {
             ip.script = script;
             ip.sampleRate = sampleRate;
             ip.metadata.putAll(metadata);
+            ip.requiresInitialContext = requireInitialContext;
             return ip;
         }
     }

--- a/james-agent-common/src/main/java/com/tomtom/james/common/api/script/ScriptEngine.java
+++ b/james-agent-common/src/main/java/com/tomtom/james/common/api/script/ScriptEngine.java
@@ -22,8 +22,16 @@ import com.tomtom.james.common.api.informationpoint.InformationPoint;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public interface ScriptEngine extends Closeable {
+
+    Object invokePrepareContext(InformationPoint informationPoint,
+                                Method origin,
+                                List<RuntimeInformationPointParameter> parameters,
+                                Object instance,
+                                Thread currentThread,
+                                String contextKey);
 
     void invokeSuccessHandler(InformationPoint informationPoint,
                               Method origin,
@@ -32,7 +40,8 @@ public interface ScriptEngine extends Closeable {
                               Thread currentThread,
                               Duration executionTime,
                               String[] callStack,
-                              Object returnValue);
+                              Object returnValue,
+                              CompletableFuture<Object> initialContextProvider);
 
     void invokeErrorHandler(InformationPoint informationPoint,
                             Method origin,
@@ -41,6 +50,7 @@ public interface ScriptEngine extends Closeable {
                             Thread currentThread,
                             Duration executionTime,
                             String[] callStack,
-                            Throwable errorCause);
+                            Throwable errorCause,
+                            CompletableFuture<Object> initialContextProvider);
 
 }

--- a/james-agent/src/main/java/com/tomtom/james/agent/Agent.java
+++ b/james-agent/src/main/java/com/tomtom/james/agent/Agent.java
@@ -23,6 +23,7 @@ import com.tomtom.james.common.log.Logger;
 import com.tomtom.james.configuration.AgentConfiguration;
 import com.tomtom.james.configuration.AgentConfigurationFactory;
 import com.tomtom.james.configuration.ConfigurationInitializationException;
+import com.tomtom.james.newagent.MethodExecutionContextHelper;
 import com.tomtom.james.publisher.EventPublisherFactory;
 import com.tomtom.james.script.ScriptEngineFactory;
 import com.tomtom.james.store.InformationPointStore;
@@ -61,7 +62,7 @@ class Agent {
             //InformationPointService informationPointService = new InformationPointServiceImpl(store, instrumentation);
             //controllersManager.initializeControllers(informationPointService, engine, publisher);
 
-            ShutdownHook shutdownHook = new ShutdownHook(controllersManager, engine, publisher, configuration);
+            ShutdownHook shutdownHook = new ShutdownHook(controllersManager, engine, publisher, configuration, () -> MethodExecutionContextHelper.shutdown());
             Runtime.getRuntime().addShutdownHook(shutdownHook);
             LOG.info("Agent initialization complete.");
         } catch (ConfigurationInitializationException e) {

--- a/james-agent/src/main/java/com/tomtom/james/agent/ShutdownHook.java
+++ b/james-agent/src/main/java/com/tomtom/james/agent/ShutdownHook.java
@@ -22,6 +22,7 @@ import com.tomtom.james.common.api.publisher.EventPublisher;
 import com.tomtom.james.common.api.script.ScriptEngine;
 import com.tomtom.james.common.log.Logger;
 import com.tomtom.james.configuration.AgentConfiguration;
+import com.tomtom.james.newagent.MethodExecutionContextHelper;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -36,13 +37,15 @@ public class ShutdownHook extends Thread {
     public ShutdownHook(ControllersManager controllersManager,
                  ScriptEngine scriptEngine,
                  EventPublisher eventPublisher,
-                 AgentConfiguration agentConfiguration) {
+                 AgentConfiguration agentConfiguration,
+                 Closeable methodExecutionContextHelper) {
         super("james-shutdown-thread");
         this.agentConfiguration = Objects.requireNonNull(agentConfiguration);
         closeables = ImmutableList.of(
                 Objects.requireNonNull(controllersManager),
                 Objects.requireNonNull(scriptEngine),
-                Objects.requireNonNull(eventPublisher));
+                Objects.requireNonNull(eventPublisher),
+                Objects.requireNonNull(methodExecutionContextHelper));
     }
 
     @Override

--- a/james-agent/src/main/java/com/tomtom/james/informationpoint/advice/ContextAwareAdvice.java
+++ b/james-agent/src/main/java/com/tomtom/james/informationpoint/advice/ContextAwareAdvice.java
@@ -45,35 +45,27 @@ public class ContextAwareAdvice {
                                Object instance,
                                Object[] arguments) {
         try {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("onEnter: START ["
+            LOG.trace(() -> "onEnter: START ["
                         + "originTypeName=" + originTypeName
                         + ", originMethodName=" + originMethodName
                         + "]");
-            }
 
             Optional<InformationPoint> informationPoint = InformationPointServiceSupplier.get()
                     .getInformationPoint(originTypeName, originMethodName);
 
             if (!informationPoint.isPresent()) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("onEnter: skipping");
-                }
+                LOG.trace(() -> "onEnter: skipping");
                 return;
             }
 
             final InformationPoint ip = informationPoint.get();
             if (!ip.getRequiresInitialContext()) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("onEnter: noInitialContextSupportRequired - skipping");
-                }
+                LOG.trace(() -> "onEnter: noInitialContextSupportRequired - skipping");
                 return;
             }
 
             final String key = MethodExecutionContextHelper.createContextKey();
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Initializing custom context setup for the call");
-            }
+            LOG.trace(() -> "Initializing custom context setup for the call");
             final Object callContext = ScriptEngineSupplier.get().invokePrepareContext(
                     ip,
                     origin,
@@ -110,32 +102,26 @@ public class ContextAwareAdvice {
             Optional<InformationPoint> informationPoint = InformationPointServiceSupplier.get()
                     .getInformationPoint(informationPointClassName, informationPointMethodName);
             if(!informationPoint.isPresent()) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("onExit: skipping because information point is gone");
-                }
+                LOG.trace(() -> "onExit: skipping because information point is gone");
                 return;
             }
             int sampleRate = informationPoint.get().getSampleRate();
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("onExit: START "
-                        + "[origin=" + origin
-                        + ", informationPointClassName=" + informationPointClassName
-                        + ", informationPointMethodName=" + informationPointMethodName
-                        + ", script=" + (informationPoint.get().getScript().orElse(null) != null)
-                        + ", sampleRate=" + informationPoint.get().getSampleRate()
-                        + ", instance=" + instance
-                        + ", arguments=" + Arrays.asList(arguments)
-                        + ", returned=" + returned
-                        + ", thrown=" + thrown
-                        + "]");
-            }
+            LOG.trace(() -> "onExit: START "
+                    + "[origin=" + origin
+                    + ", informationPointClassName=" + informationPointClassName
+                    + ", informationPointMethodName=" + informationPointMethodName
+                    + ", script=" + (informationPoint.get().getScript().orElse(null) != null)
+                    + ", sampleRate=" + informationPoint.get().getSampleRate()
+                    + ", instance=" + instance
+                    + ", arguments=" + Arrays.asList(arguments)
+                    + ", returned=" + returned
+                    + ", thrown=" + thrown
+                    + "]");
 
             requireInitialContextCleanup = informationPoint.get().getRequiresInitialContext();
 
             if ((sampleRate < 100) && (sampleRate < RND.nextDouble() * 100)) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("onExit: Sample skipped (sampleRate=" + sampleRate + ")");
-                }
+                LOG.trace(() -> "onExit: Sample skipped (sampleRate=" + sampleRate + ")");
                 return;
             }
 
@@ -144,7 +130,7 @@ public class ContextAwareAdvice {
                     : CompletableFuture.completedFuture(null);
 
             if (thrown == null) {
-                LOG.trace("onExit: Invoking success handler");
+                LOG.trace(() -> "onExit: Invoking success handler");
                 ScriptEngineSupplier.get().invokeSuccessHandler(
                         informationPoint.get(),
                         origin,
@@ -157,7 +143,7 @@ public class ContextAwareAdvice {
                         initialContextAsyncProvider
                 );
             } else {
-                LOG.trace("onExit: Invoking error handler");
+                LOG.trace(() -> "onExit: Invoking error handler");
                 ScriptEngineSupplier.get().invokeErrorHandler(
                         informationPoint.get(),
                         origin,

--- a/james-agent/src/main/java/com/tomtom/james/newagent/JVMAgent.java
+++ b/james-agent/src/main/java/com/tomtom/james/newagent/JVMAgent.java
@@ -174,7 +174,7 @@ public class JVMAgent {
 
 
 
-            ShutdownHook shutdownHook = new ShutdownHook(controllersManager, engine, publisher, configuration);
+            ShutdownHook shutdownHook = new ShutdownHook(controllersManager, engine, publisher, configuration, () -> MethodExecutionContextHelper.shutdown());
             Runtime.getRuntime().addShutdownHook(shutdownHook);
             LOG.trace("shutdownHook time=" + stopwatch.elapsed());
             stopwatch.stop();

--- a/james-agent/src/main/java/com/tomtom/james/newagent/MethodExecutionContextHelper.java
+++ b/james-agent/src/main/java/com/tomtom/james/newagent/MethodExecutionContextHelper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 TomTom International B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tomtom.james.newagent;
+
+import com.tomtom.james.common.log.Logger;
+import com.tomtom.james.util.MoreExecutors;
+
+import java.util.ArrayDeque;
+import java.util.UUID;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class MethodExecutionContextHelper {
+    private static final Logger LOG = Logger.getLogger(MethodExecutionContextHelper.class);
+
+    public static ThreadLocal<ArrayDeque<String>> keysStack = ThreadLocal.withInitial(() -> new ArrayDeque<>(8));
+    private static WeakHashMap<String, Object> contextStore = new WeakHashMap<>();
+
+    private static ExecutorService contextStoreAccessExecutor = MoreExecutors
+            .createNamedDaemonExecutorService("james-context-access-%d", 1);
+
+    private static ExecutorService contextCallbackExecutor = MoreExecutors
+            .createNamedDaemonExecutorService("james-context-callback-%d", 5);
+
+    public static void shutdown() {
+        /*
+        try {
+            contextStoreAccessExecutor.shutdown();
+            contextStoreAccessExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOG.warn("Executor contextStoreAccessExecutor shutdown interrupted " + e);
+        }
+        try {
+            contextCallbackExecutor.shutdown();
+            contextStoreAccessExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOG.warn("Executor contextCallbackExecutor shutdown interrupted " + e);
+        }*/
+    }
+
+    public static String createContextKey() {
+        final String contextKey = UUID.randomUUID().toString();
+        keysStack.get().push(contextKey);
+        return contextKey;
+    }
+
+    public static String getKeyForCurrentFrame() {
+        return keysStack.get().peek();
+    }
+
+    public static String removeContextKey() {
+        return keysStack.get().pop();
+    }
+
+    public static CompletableFuture<Object> storeContextAsync(final String key, final Object value) {
+        final CompletableFuture result = new CompletableFuture();
+        contextStoreAccessExecutor.submit(() -> {
+            contextStore.put(key, value);
+            CompletableFuture.supplyAsync(() -> result.complete(value), contextCallbackExecutor);
+        });
+        return result;
+    }
+
+    public static CompletableFuture<Object> getContextAsync(final String key) {
+        final CompletableFuture result = new CompletableFuture();
+        contextStoreAccessExecutor.submit(() -> {
+            if (contextStore.containsKey(key)) {
+                final Object context = contextStore.get(key);
+                CompletableFuture.supplyAsync(() -> result.complete(context), contextCallbackExecutor);
+                return;
+            }
+
+            CompletableFuture.supplyAsync(() -> {
+                final String msg = String.format("Key '%s' not found in context container", key);
+                result.completeExceptionally(new IllegalArgumentException(msg));
+                return null;
+            }, contextCallbackExecutor);
+        });
+        return result;
+    }
+}

--- a/james-agent/src/main/java/com/tomtom/james/newagent/MethodExecutionContextHelper.java
+++ b/james-agent/src/main/java/com/tomtom/james/newagent/MethodExecutionContextHelper.java
@@ -39,7 +39,6 @@ public class MethodExecutionContextHelper {
             .createNamedDaemonExecutorService("james-context-callback-%d", 5);
 
     public static void shutdown() {
-        /*
         try {
             contextStoreAccessExecutor.shutdown();
             contextStoreAccessExecutor.awaitTermination(5, TimeUnit.SECONDS);
@@ -51,7 +50,7 @@ public class MethodExecutionContextHelper {
             contextStoreAccessExecutor.awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             LOG.warn("Executor contextCallbackExecutor shutdown interrupted " + e);
-        }*/
+        }
     }
 
     public static String createContextKey() {

--- a/james-agent/src/main/java/com/tomtom/james/newagent/james/GroovyJames.java
+++ b/james-agent/src/main/java/com/tomtom/james/newagent/james/GroovyJames.java
@@ -26,7 +26,17 @@ public class GroovyJames extends AbstractJames {
 
     protected void insertBefore(CtMethod method, ExtendedInformationPoint informationPoint) throws CannotCompileException {
         StringBuilder s = new StringBuilder("");
-        s.append(" com.tomtom.james.newagent.MethodExecutionTimeHelper.executionStarted();");
+        s.append(" com.tomtom.james.newagent.MethodExecutionTimeHelper.executionStarted();\n");
+        s.append(" com.tomtom.james.informationpoint.advice.ContextAwareAdvice.onEnter(");
+        s.append("\"" + informationPoint.getClassName() + "\", ");
+        s.append("\"" + informationPoint.getMethodName() + "\", ");
+        s.append(", " + informationPoint.getMethodBodyClassName() + ".class.getDeclaredMethod(\"" + informationPoint.getMethodName() + "\",$sig), "); // method
+        if (Modifier.isStatic(method.getModifiers()) || method.isEmpty()) {
+            s.append("null"); // this is static method - no instance
+        } else {
+            s.append("$0"); // this
+        }
+        s.append(");\n");
         method.insertBefore(s.toString());
     }
 

--- a/james-agent/src/main/java/com/tomtom/james/script/ErrorHandlerContext.java
+++ b/james-agent/src/main/java/com/tomtom/james/script/ErrorHandlerContext.java
@@ -35,9 +35,10 @@ public final class ErrorHandlerContext extends InformationPointHandlerContext {
                                Thread currentThread,
                                Duration executionTime,
                                String[] callStack,
-                               Throwable errorCause) {
+                               Throwable errorCause,
+                               Object initialContext) {
         super(informationPointClassName, informationPointMethodName, origin, runtimeParameters, runtimeInstance,
-                currentThread, executionTime, callStack);
+                currentThread, executionTime, callStack, initialContext);
         this.errorCause = errorCause;
     }
 

--- a/james-agent/src/main/java/com/tomtom/james/script/InformationPointContext.java
+++ b/james-agent/src/main/java/com/tomtom/james/script/InformationPointContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 TomTom International B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tomtom.james.script;
+
+import com.tomtom.james.common.api.script.RuntimeInformationPointParameter;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+public abstract class InformationPointContext {
+    final String informationPointClassName;
+    final String informationPointMethodName;
+    final Method origin;
+    final Object runtimeInstance;
+    final List<RuntimeInformationPointParameter> runtimeParameters;
+    final Thread currentThread;
+
+    public InformationPointContext(
+            String informationPointClassName,
+            String informationPointMethodName,
+            Method origin,
+            Object runtimeInstance,
+            List<RuntimeInformationPointParameter> runtimeParameters,
+            Thread currentThread) {
+        this.informationPointClassName = informationPointClassName;
+        this.informationPointMethodName = informationPointMethodName;
+        this.origin = origin;
+        this.runtimeInstance = runtimeInstance;
+        this.runtimeParameters = runtimeParameters;
+        this.currentThread = currentThread;
+    }
+
+    @SuppressWarnings("unused")
+    public String getInformationPointClassName() {
+        return informationPointClassName;
+    }
+
+    @SuppressWarnings("unused")
+    public String getInformationPointMethodName() {
+        return informationPointMethodName;
+    }
+
+    @SuppressWarnings("unused")
+    public Method getOrigin() {
+        return origin;
+    }
+
+    @SuppressWarnings("unused")
+    public List<RuntimeInformationPointParameter> getParameters() {
+        return runtimeParameters;
+    }
+
+    @SuppressWarnings("unused")
+    public Object getInstance() {
+        return runtimeInstance;
+    }
+
+    @SuppressWarnings("unused")
+    public Thread getCurrentThread() {
+        return currentThread;
+    }
+}

--- a/james-agent/src/main/java/com/tomtom/james/script/InformationPointHandlerContext.java
+++ b/james-agent/src/main/java/com/tomtom/james/script/InformationPointHandlerContext.java
@@ -22,16 +22,11 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 
-public abstract class InformationPointHandlerContext {
+public abstract class InformationPointHandlerContext extends InformationPointContext {
 
-    final String informationPointClassName;
-    final String informationPointMethodName;
-    final Method origin;
-    final Object runtimeInstance;
-    final List<RuntimeInformationPointParameter> runtimeParameters;
-    final Thread currentThread;
     final Duration executionTime;
     final String[] callStack;
+    final Object initialContext;
 
     InformationPointHandlerContext(String informationPointClassName,
                                    String informationPointMethodName,
@@ -40,45 +35,12 @@ public abstract class InformationPointHandlerContext {
                                    Object runtimeInstance,
                                    Thread currentThread,
                                    Duration executionTime,
-                                   String[] callStack) {
-        this.informationPointClassName = informationPointClassName;
-        this.informationPointMethodName = informationPointMethodName;
-        this.origin = origin;
-        this.runtimeParameters = runtimeParameters;
-        this.runtimeInstance = runtimeInstance;
-        this.currentThread = currentThread;
+                                   String[] callStack,
+                                   Object initialContext) {
+        super(informationPointClassName, informationPointMethodName, origin, runtimeInstance, runtimeParameters, currentThread);
         this.executionTime = executionTime;
         this.callStack = callStack;
-    }
-
-    @SuppressWarnings("unused")
-    public String getInformationPointClassName() {
-        return informationPointClassName;
-    }
-
-    @SuppressWarnings("unused")
-    public String getInformationPointMethodName() {
-        return informationPointMethodName;
-    }
-
-    @SuppressWarnings("unused")
-    public Method getOrigin() {
-        return origin;
-    }
-
-    @SuppressWarnings("unused")
-    public List<RuntimeInformationPointParameter> getParameters() {
-        return runtimeParameters;
-    }
-
-    @SuppressWarnings("unused")
-    public Object getInstance() {
-        return runtimeInstance;
-    }
-
-    @SuppressWarnings("unused")
-    public Thread getCurrentThread() {
-        return currentThread;
+        this.initialContext = initialContext;
     }
 
     @SuppressWarnings("unused")
@@ -91,4 +53,8 @@ public abstract class InformationPointHandlerContext {
         return callStack;
     }
 
+    @SuppressWarnings("unused")
+    public Object getInitialContext() {
+        return initialContext;
+    }
 }

--- a/james-agent/src/main/java/com/tomtom/james/script/PrepareContextHandlerContext.java
+++ b/james-agent/src/main/java/com/tomtom/james/script/PrepareContextHandlerContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 TomTom International B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tomtom.james.script;
+
+import com.tomtom.james.common.api.script.RuntimeInformationPointParameter;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class PrepareContextHandlerContext extends InformationPointContext {
+
+    final String key;
+
+    public PrepareContextHandlerContext(
+            String informationPointClassName,
+            String informationPointMethodName,
+            Method origin,
+            Object runtimeInstance,
+            List<RuntimeInformationPointParameter> runtimeParameters,
+            Thread currentThread,
+            String key) {
+
+        super(  informationPointClassName,
+                informationPointMethodName,
+                origin,
+                runtimeInstance,
+                runtimeParameters,
+                currentThread);
+        this.key = key;
+    }
+
+
+    @SuppressWarnings("unused")
+    public String getKey() {
+        return key;
+    }
+}

--- a/james-agent/src/main/java/com/tomtom/james/script/SuccessHandlerContext.java
+++ b/james-agent/src/main/java/com/tomtom/james/script/SuccessHandlerContext.java
@@ -35,9 +35,10 @@ public final class SuccessHandlerContext extends InformationPointHandlerContext 
                           Thread currentThread,
                           Duration executionTime,
                           String[] callStack,
-                          Object returnValue) {
+                          Object returnValue,
+                          Object initialContext) {
         super(informationPointClassName, informationPointMethodName, origin, runtimeParameters,
-                runtimeInstance, currentThread, executionTime, callStack);
+                runtimeInstance, currentThread, executionTime, callStack, initialContext);
         this.returnValue = returnValue;
     }
 

--- a/james-agent/src/test/groovy/com/tomtom/james/agent/ShutdownHookSpec.groovy
+++ b/james-agent/src/test/groovy/com/tomtom/james/agent/ShutdownHookSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.tomtom.james.agent
 
+import com.tomtom.james.common.api.Closeable
 import com.tomtom.james.common.api.publisher.EventPublisher
 import com.tomtom.james.common.api.script.ScriptEngine
 import com.tomtom.james.configuration.AgentConfiguration
@@ -27,8 +28,9 @@ class ShutdownHookSpec extends Specification {
     def scriptEngine = Mock(ScriptEngine)
     def eventPublisher = Mock(EventPublisher)
     def agentConfiguration = Mock(AgentConfiguration)
+    def methodExecutionHelper = Mock(Closeable)
 
-    def shutdownHook = new ShutdownHook(controllersManager, scriptEngine, eventPublisher, agentConfiguration)
+    def shutdownHook = new ShutdownHook(controllersManager, scriptEngine, eventPublisher, agentConfiguration, methodExecutionHelper)
 
     def "Should close resources on execution"() {
         when:
@@ -38,5 +40,6 @@ class ShutdownHookSpec extends Specification {
         1 * controllersManager.close()
         1 * scriptEngine.close()
         1 * eventPublisher.close()
+        1 * methodExecutionHelper.close()
     }
 }

--- a/james-agent/src/test/groovy/com/tomtom/james/newagent/MethodExecutionContextHelperSpec.groovy
+++ b/james-agent/src/test/groovy/com/tomtom/james/newagent/MethodExecutionContextHelperSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 TomTom International B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tomtom.james.newagent
+
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+import static org.awaitility.Awaitility.await
+
+class MethodExecutionContextHelperSpec extends Specification {
+
+    def "Should store context per thread"() {
+        given:
+        def keys = new String[2]
+
+        when:
+        def th1 = new Thread( { runOnThread(keys, 0) })
+        def th2 = new Thread( { runOnThread(keys, 1) })
+        th1.start()
+        th2.start()
+
+        await().atMost(5, TimeUnit.SECONDS).until({ !th1.isAlive() && !th2.isAlive() })
+
+        def context_value1 = MethodExecutionContextHelper.getContextAsync(keys[0]).get()
+        def context_value2 = MethodExecutionContextHelper.getContextAsync(keys[1]).get()
+        then:
+        Integer.valueOf(100) == context_value1
+        Integer.valueOf(101) == context_value2
+    }
+
+    static def runOnThread(String[] storage, int index) {
+        String key = MethodExecutionContextHelper.createContextKey()
+        storage[index] = key
+        MethodExecutionContextHelper.storeContextAsync(key, Integer.valueOf(100 + index))
+        MethodExecutionContextHelper.removeContextKey()
+    }
+}

--- a/james-agent/src/test/groovy/com/tomtom/james/script/AsyncScriptEngineSpec.groovy
+++ b/james-agent/src/test/groovy/com/tomtom/james/script/AsyncScriptEngineSpec.groovy
@@ -19,14 +19,17 @@ package com.tomtom.james.script
 import com.tomtom.james.common.api.informationpoint.InformationPoint
 import com.tomtom.james.common.api.script.RuntimeInformationPointParameter
 import com.tomtom.james.common.api.script.ScriptEngine
+import com.tomtom.james.newagent.MethodExecutionContextHelper
 import spock.lang.Specification
 
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 import static org.awaitility.Awaitility.await
+import static org.awaitility.Awaitility.given
 
 class AsyncScriptEngineSpec extends Specification {
 
@@ -44,13 +47,21 @@ class AsyncScriptEngineSpec extends Specification {
     def origin = null
     def currentThread = Mock(Thread)
     def informationPoint = Mock(InformationPoint)
+    def threadData = new ThreadLocal<String>()
+    def contextValue = null
 
     def successCallerThreadNames = new ArrayBlockingQueue<String>(10000)
     def errorCallerThreadNames = new ArrayBlockingQueue<String>(10000)
 
     def setup() {
-        delegate.invokeSuccessHandler(*_) >> { successCallerThreadNames.add(Thread.currentThread().getName()) }
+        delegate.invokeSuccessHandler(*_) >> {
+            args ->
+                successCallerThreadNames.add(Thread.currentThread().getName())
+                contextValue = args[8].get()
+        }
         delegate.invokeErrorHandler(*_) >> { errorCallerThreadNames.add(Thread.currentThread().getName()) }
+        delegate.invokePrepareContext(_, _, _, _, _, _) >> {
+            args -> return args[5] + threadData.get() }
     }
 
     def "Should invoke success handler via the delegate in the background"() {
@@ -60,7 +71,7 @@ class AsyncScriptEngineSpec extends Specification {
         when:
         10.times {
             scriptEngine.invokeSuccessHandler(informationPoint, origin,
-                    [param1, param2], instance, currentThread, duration, callStack, returnValue)
+                    [param1, param2], instance, currentThread, duration, callStack, returnValue, CompletableFuture.completedFuture(null))
         }
         await().atMost(5, TimeUnit.SECONDS).until { successCallerThreadNames.size() == 10 }
 
@@ -76,13 +87,30 @@ class AsyncScriptEngineSpec extends Specification {
         when:
         10.times {
             scriptEngine.invokeErrorHandler(informationPoint, origin,
-                    [param1, param2], instance, currentThread, duration, callStack, errorCause)
+                    [param1, param2], instance, currentThread, duration, callStack, errorCause, CompletableFuture.completedFuture(null))
         }
         await().atMost(5, TimeUnit.SECONDS).until { errorCallerThreadNames.size() == 10 }
 
         then:
         errorCallerThreadNames.size() == 10
         errorCallerThreadNames.findAll({ it.contains("async-script-engine-thread-pool") }).size() == 10
+    }
+
+    def "Shoud invoke prepare context in current thread and allow access to it in background thread handler"() {
+        given:
+        def scriptEngine = new AsyncScriptEngine(delegate, 5, 100)
+
+        when:
+        threadData.set("greetings from " + currentThread.getId())
+        def key = MethodExecutionContextHelper.createContextKey()
+        def context = scriptEngine.invokePrepareContext(informationPoint, origin, [param1, param2], instance, currentThread, key)
+        MethodExecutionContextHelper.storeContextAsync(key, context)
+        scriptEngine.invokeSuccessHandler(informationPoint, origin, [param1, param2], instance, currentThread, duration, callStack, returnValue, MethodExecutionContextHelper.getContextAsync(key))
+        await().atMost(5, TimeUnit.SECONDS).until{ successCallerThreadNames.size() == 1 }
+
+        then:
+        context == contextValue
+        !successCallerThreadNames.contains(currentThread.getName())
     }
 
 }


### PR DESCRIPTION
Added support to call onPrepareContext script - this script (if defined) will be executed in context of method's calling thread - this allows building additional context with thread specific data.
Note - this method is invoked in the calling thread context - it should never execute any IO operations or calculation intensive operations. 
The usage of this method should be limited to getting data out of thread local context or capturing the caller instance and or parameters state at method entry.