### PR TITLE
fix: fix support for JDK 11

### DIFF
--- a/james-agent/build.gradle
+++ b/james-agent/build.gradle
@@ -30,17 +30,15 @@ jar {
 }
 
 shadowJar {
+    exclude '**/services/org.apache.logging.log4j.util.*'
+    exclude('module-info.class', '**/9/module-info.class')
     relocate 'com.google', 'com.tomtom.james.repackaged.com.google'
     relocate 'com.fasterxml.jackson', 'com.tomtom.james.repackaged.com.fasterxml.jackson'
     relocate 'org.yaml.snakeyaml', 'com.tomtom.james.repackaged.org.yaml.snakeyaml'
     relocate 'com.lmax.disruptor', 'com.tomtom.james.repackaged.com.lmax.disruptor'
+    relocate 'org.apache.logging', 'com.tomtom.james.repackaged.org.apache.logging'
+    relocate 'META-INF.versions.9.org.apache.logging', 'META-INF.versions.9.com.tomtom.james.repackaged.org.apache.logging'
 
-    from { // dont reinvent the wheel, take StackLocator from log4j4 as guys done great job
-        project.configurations.compileOnly.collect {
-            zipTree(it).matching
-                    { includes = ["**/apache/logging/log4j/util/StackLocator*"] }
-        }
-    }
 }
 assemble.dependsOn(shadowJar)
 
@@ -61,8 +59,7 @@ dependencies {
     compile group: 'org.javassist', name: 'javassist', version: versions.javassist
     compile group: 'org.apache.commons', name: 'commons-lang3', version: versions.commonslang
     compile group: 'com.lmax', name: 'disruptor', version: versions.disruptor
-    compileOnly group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j_stackutil
-    testRuntimeOnly group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j_stackutil
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: versions.log4j_stackutil
 
     testCompile group: 'org.spockframework', name: 'spock-core', version: versions.spock
     testCompile group: 'org.awaitility', name: 'awaitility', version: versions.awaitility

--- a/james-publisher-aws-kinesis/build.gradle
+++ b/james-publisher-aws-kinesis/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile project(':james-agent-common')
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
     compile group: 'com.amazonaws', name: 'amazon-kinesis-producer', version: '0.12.9'
+    compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
 
     compile group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.11.1'
 }


### PR DESCRIPTION
relocate log4j utils as it conflict with application ones
include API for jaxb in kinesis publisher