### PR TITLE
change default rejected policy for James to avoid exposing RejectedExecutionException

### DIFF
--- a/james-agent/src/main/java/com/tomtom/james/util/MoreExecutors.java
+++ b/james-agent/src/main/java/com/tomtom/james/util/MoreExecutors.java
@@ -20,7 +20,10 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class MoreExecutors {
 
@@ -35,6 +38,10 @@ public class MoreExecutors {
                 .setNameFormat(threadPoolNameFormat)
                 .setDaemon(true)
                 .build();
-        return Executors.newFixedThreadPool(numberOfWorkers, threadFactory);
+        return new ThreadPoolExecutor(numberOfWorkers, numberOfWorkers,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                threadFactory,
+                new ThreadPoolExecutor.DiscardPolicy());
     }
 }


### PR DESCRIPTION
we have got 
```
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@1735cb08[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@2bb33379[Wrapped task = com.tomtom.james.newagent.MethodExecutionContextHelper$$Lambda$1191/0x0000000840bd1040@1cd5e340]] rejected from java.util.concurrent.ThreadPoolExecutor@4f5356b4[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 5670]
``` from James to code which is not expected and desired.